### PR TITLE
replace linkchecker with W3C checklink

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,16 +71,20 @@ RUN apt-get update && apt-get --yes --no-install-recommends --no-install-suggest
      fonts-junicode \ 
      fonts-noto-cjk \
      jing \ 
+     libcss-dom-perl \
      libfile-fcntllock-perl \ 
      libjing-java \ 
      libsaxon-java \ 
-     libsaxonhe-java \ 
-     libtrang-java \ 
+     libsaxonhe-java \
+     libterm-readkey-perl \
+     libtrang-java \
+     libwww-perl \
      libxml2-utils \ 
-     linkchecker \ 
      linuxdoc-tools \ 
      lmodern \
-     maven \ 
+     make \
+     maven \
+     perl-modules \
      psgml \ 
      texlive-fonts-recommended \ 
      texlive-generic-recommended \ 
@@ -91,6 +95,10 @@ RUN apt-get update && apt-get --yes --no-install-recommends --no-install-suggest
      xsltproc \ 
      zip \
      && rm -rf /var/lib/apt/lists/*
+
+# Install W3C linkchecker skript "checklink"
+# https://dev.w3.org/perl/modules/W3C/LinkChecker/docs/checklink
+RUN PERL_MM_USE_DEFAULT=1 perl -MCPAN -e 'install W3C::LinkChecker'
 
 # create a simple shell wrapper script for the 
 # saxon.jar provided by the Debian libsaxonhe-java package 

--- a/jobs/Guidelines-Link-Check/config.xml
+++ b/jobs/Guidelines-Link-Check/config.xml
@@ -31,19 +31,21 @@ VERSION=`cat ${VERSIONFILE}`
 TARGET=$JENKINS_HOME/jobs/TEIP5-dev/lastSuccessful/archive/P5/release/doc/tei-p5-doc/en/html/index.html
 
 
-echo &quot;Running link checking for P5 version $VERSION.&quot;
-        
-case &quot;$VERSION&quot; in
-*[a-z])  echo &quot;Using configuration for pre-release version.&quot;;
-  linkchecker --config=$JENKINS_HOME/jobs/Guidelines-Link-Check/linkcheckerrcalphabeta $TARGET ;;
-*) echo &quot;Using configuration for release version.&quot;;
-  linkchecker --config=$JENKINS_HOME/jobs/Guidelines-Link-Check/linkcheckerrcrelease $TARGET ;;
+echo "Running link checking for P5 version $VERSION."
+
+case "$VERSION" in
+*[a-z])  echo "Using configuration for pre-release version.";
+W3C_CHECKLINK_CFG=$JENKINS_HOME/jobs/Guidelines-Link-Check/linkcheckerrcalphabeta;
+checklink -e -q -D6 -X ".+readme-\d\.\d\.\d\.html" $TARGET ;;
+*) echo "Using configuration for release version.";
+W3C_CHECKLINK_CFG=$JENKINS_HOME/jobs/Guidelines-Link-Check/linkcheckerrcrelease;
+checklink -e -q -D6 -X ".+readme-\d\.\d\.\d\.html" $TARGET ;;
 esac
-        
-echo &quot;Transforming checker report...&quot;
-saxon -s:$JENKINS_HOME/workspace/Guidelines-Link-Check/checkResults/linkchecker-out.xml -xsl:$JENKINS_HOME/jobs/Guidelines-Link-Check/linkchecker.xsl
-echo &quot;Done!&quot;
-exit</command>
+
+#echo "Transforming checker report..."
+#saxon -s:$JENKINS_HOME/workspace/Guidelines-Link-Check/checkResults/linkchecker-out.xml -xsl:$JENKINS_HOME/jobs/Guidelines-Link-Check/linkchecker.xsl
+#echo "Done!"
+#exit</command>
     </hudson.tasks.Shell>
   </builders>
   <publishers>

--- a/jobs/Guidelines-Link-Check/config.xml
+++ b/jobs/Guidelines-Link-Check/config.xml
@@ -35,10 +35,10 @@ echo "Running link checking for P5 version $VERSION."
 
 case "$VERSION" in
 *[a-z])  echo "Using configuration for pre-release version.";
-W3C_CHECKLINK_CFG=$JENKINS_HOME/jobs/Guidelines-Link-Check/linkcheckerrcalphabeta;
+export W3C_CHECKLINK_CFG=$JENKINS_HOME/jobs/Guidelines-Link-Check/linkcheckerrcalphabeta;
 checklink -e -q -D6 -X ".+readme-\d\.\d\.\d\.html" $TARGET ;;
 *) echo "Using configuration for release version.";
-W3C_CHECKLINK_CFG=$JENKINS_HOME/jobs/Guidelines-Link-Check/linkcheckerrcrelease;
+export W3C_CHECKLINK_CFG=$JENKINS_HOME/jobs/Guidelines-Link-Check/linkcheckerrcrelease;
 checklink -e -q -D6 -X ".+readme-\d\.\d\.\d\.html" $TARGET ;;
 esac
 

--- a/jobs/Guidelines-Link-Check/config.xml
+++ b/jobs/Guidelines-Link-Check/config.xml
@@ -39,7 +39,7 @@ export W3C_CHECKLINK_CFG=$JENKINS_HOME/jobs/Guidelines-Link-Check/linkcheckerrca
 checklink -e -q -D6 -X ".+readme-\d\.\d\.\d\.html" $TARGET ;;
 *) echo "Using configuration for release version.";
 export W3C_CHECKLINK_CFG=$JENKINS_HOME/jobs/Guidelines-Link-Check/linkcheckerrcrelease;
-checklink -e -q -D6 -X ".+readme-\d\.\d\.\d\.html" $TARGET ;;
+checklink -e -q -D6 $TARGET ;;
 esac
 
 #echo "Transforming checker report..."

--- a/jobs/Guidelines-Link-Check/linkcheckerrcalphabeta
+++ b/jobs/Guidelines-Link-Check/linkcheckerrcalphabeta
@@ -1,29 +1,4 @@
-[checking]
-anchors=1
-recursionlevel=6
-
-[output]
-#log=xml
-fileoutput=xml
-quiet=1
-status=0
-
-[xml]
-filename=checkResults/linkchecker-out.xml
-
-[filtering]
-
-#This is a multiline thing; each line is a regex specifying something to be ignored.
-#In pre-release mode, we ignore the missing readme file for the next release.
-#We always ignore the mobi, because any given server may not be building it.
-#We ignore tei-c links, google stuff, and unfollowable XPointers.
-#We ignore archive.org links of a particular type because linkchecker does not
-#follow them correctly.
-
-ignore=readme-\d\.\d\.\d\.html
-  Guidelines\.mobi
-  tei-c.org/$
-  google\.com/search
-  #xpointer(id('chum'))
-  http://web.archive.org/web/
-
+# "Forbidden_Protocols" is a comma separated list of additional protocols/URI schemes
+# that the link checker is not allowed to use.  The "javascript" and "mailto" schemes
+# are always forbidden, and so is the "file" scheme when running as a CGI script.
+Forbidden_Protocols = javascript,mailto,about

--- a/jobs/Guidelines-Link-Check/linkcheckerrcrelease
+++ b/jobs/Guidelines-Link-Check/linkcheckerrcrelease
@@ -1,27 +1,4 @@
-[checking]
-anchors=1
-recursionlevel=6
-
-[output]
-#log=xml
-fileoutput=xml
-quiet=1
-status=0
-
-[xml]
-filename=checkResults/linkchecker-out.xml
-
-[filtering]
-
-#This is a multiline thing; each line is a regex specifying something to be ignored.
-#We always ignore the mobi, because any given server may not be building it.
-#We ignore tei-c links, google stuff, and unfollowable XPointers.
-#We ignore archive.org links of a particular type because linkchecker does not
-#follow them correctly.
-
-ignore=Guidelines\.mobi
-  tei-c\.org/$
-  google\.com/search
-  #xpointer(id('chum'))
-  http://web.archive.org/web/
-
+# "Forbidden_Protocols" is a comma separated list of additional protocols/URI schemes
+# that the link checker is not allowed to use.  The "javascript" and "mailto" schemes
+# are always forbidden, and so is the "file" scheme when running as a CGI script.
+Forbidden_Protocols = javascript,mailto,about


### PR DESCRIPTION
This PR replaces updates our Guidelines-Link-Check job to use the W3C checklink rather than the old linkchecker. Changes are made to the Docker image as well as to the job configuration to achieve the switch. 

While it's working in general (and is already deployed at https://jenkins2.tei-c.de/job/Guidelines-Link-Check/), some things could need some polish (or are debatable):

* the log output from checklink is spit out to the Jenkins console without further transformation. To make this properly fail or validate we need some addition to the log parsing rules or we reemploy some sort of post processing of the logs
* the list of exceptions is rather small now. If I read the [man page](http://manpages.ubuntu.com/manpages/bionic/man1/checklink.1p.html) correctly, the `-X` parameter is allowed only once, so the exceptions would need to be turned into one ugly (long) regex
