### PR TITLE
add tidy to format html ouputs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,6 +80,7 @@ RUN apt-get update && apt-get --yes --no-install-recommends --no-install-suggest
      libtrang-java \
      libwww-perl \
      libxml2-utils \ 
+     tidy \
      linuxdoc-tools \ 
      lmodern \
      make \


### PR DESCRIPTION
As discussed in our last Stylesheets meeting, we are going to format the HTML outputs using `tidy` instead of `xmllint` due to the changes generated by the latter when formatting HTML5 outputs.