### PR TITLE
Adjust Dockerfile to upstream changes of our Jenkins:lts base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,9 +34,7 @@ ENV LANG=C.UTF-8
 # Need to switch to root user to install stuff.
 USER root
 
-# Install a bunch of packages we need. This package list has been 
-# customized a little from the original 2016 builder script set,
-# because we're working with Debian Jessie instead of Ubuntu.
+# Install a bunch of packages we need.
 # Many required packages are already installed upstream. 
 # Various tex-related packages have been added as build failures
 # revealed the need for them.

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,6 +75,7 @@ RUN apt-get update && apt-get -y --no-install-recommends --no-install-suggests i
      perl-modules \
      psgml \
      texlive-fonts-recommended \
+     texlive-lang-greek \
      texlive-plain-generic \
      texlive-latex-extra \
      texlive-xetex \

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,7 @@ RUN apt-get update && apt-get -y --no-install-recommends --no-install-suggests i
      fonts-linuxlibertine \
      # provides Noto font families for Traditional Chinese, Simplified Chinese, Japanese and Korean, see https://packages.debian.org/buster/fonts-noto-cjk
      fonts-dejavu \
+     fonts-junicode \
      fonts-noto-cjk \
      jing \
      libcss-dom-perl \
@@ -81,11 +82,6 @@ RUN apt-get update && apt-get -y --no-install-recommends --no-install-suggests i
      xmlstarlet \
      xsltproc \
      zip \
-     && apt-get -y dist-upgrade \
-     && echo 'APT::Default-Release "bookworm";' > /etc/apt/apt.conf.d/default-release \
-     && echo "deb http://deb.debian.org/debian/ testing main" > /etc/apt/sources.list.d/testing.list \
-     && apt update \
-     && apt-get -y --no-install-recommends --no-install-suggests install fonts-junicode/testing \
      && rm -rf /var/lib/apt/lists/*
 
 # Building `rnv` locally since it's no 


### PR DESCRIPTION
Apparently our base image `jenkins/jenkins:lts` is based on Debian Trixie now (see [Release 2.530](https://github.com/jenkinsci/docker/releases/tag/2.530) and [Issue #2062](https://github.com/jenkinsci/docker/issues/2062)) so we need to adjust some minor things:

1. we can get the `fonts-junicode` package through standard apt install rather than from the testing repo
2. we need to introduce the `texlive-lang-greek` package for adding the missing file `puenc-greek.def`

I have tested this image locally by creating a PDF output of the Guidelines (for I assume these changes might affect the PDF only) and my [`diff-pdf`](https://vslavik.github.io/diff-pdf/) tool did not mark any visual differences between the current `teic/jenkins:dev` image and my local image.

For the record, here's a diff of the Guidelines.log: [Guidelines-diff.txt](https://github.com/user-attachments/files/22945724/Guidelines-diff.txt)

